### PR TITLE
Timestep corrections

### DIFF
--- a/config/ebtel.example.cfg.xml
+++ b/config/ebtel.example.cfg.xml
@@ -13,7 +13,8 @@
   <save_terms>False</save_terms>
   <use_adaptive_solver>False</use_adaptive_solver>
   <output_filename>ebtel++_results_file.txt</output_filename>
-  <rka_error>1e-6</rka_error>
+  <adaptive_solver_error>1e-6</adaptive_solver_error>
+  <adaptive_solver_safety>1.0</adaptive_solver_safety>
   <c1_cond0>6.0</c1_cond0>
   <c1_rad0>0.6</c1_rad0>
   <helium_to_hydrogen_ratio>0.075</helium_to_hydrogen_ratio>

--- a/docs/ext/index.md
+++ b/docs/ext/index.md
@@ -83,9 +83,10 @@ An ebtel++ run is configured by a single XML configuration file. The table below
 | `use_flux_limiting` | bool | impose a flux limiter according to Eq. 22 of [Klimchuk et al. (2008)][klimchuk_2008] |
 | `calculate_dem` | bool | if True, do the TR and coronal DEM calculation; increases compute time significantly |
 | `save_terms` | bool | if True, save heat flux, c1 parameter, and radiative loss to a separate file `output_filename`+`.terms` |
-| `use_adaptive_solver` | bool | if True, use adaptive timestep with tolerance set by `rka_error`; in both cases, a Runge-Kutta Cash-Karp integration method is used (see section 16.2 of [Press et al. (1992)][press_num_recipes])  |
+| `use_adaptive_solver` | bool | if True, use adaptive timestep; significantly smaller compute times. In both cases, a Runge-Kutta Cash-Karp integration method is used (see section 16.2 of [Press et al. (1992)][press_num_recipes])  |
 | `output_filename` | string | path to output file |
-| `rka_error` | float | Allowed truncation error in adaptive timestep routine |
+| `adaptive_solver_error` | float | Allowed truncation error in adaptive timestep routine |
+| `adaptive_solver_safety` | float | Limit on the allowed maximum timestep in units of the shortest event duration; should always be between 0 and 1. Not important for single or closely-spaced events |
 | `c1_cond0` | float | Nominal value of c1 during the conduction phase; see Appendix A of [Barnes et al. (2016)][barnes_2016] |
 | `c1_rad0` | float | Nominal value of c1 during radiative phase; see Eq. 16 of [Cargill et al. (2012a)][cargill_2012a] |
 | `helium_to_hydrogen_ratio` | float | Ratio of helium to hydrogen abundance; used in correction to ion mass, ion equation of state |

--- a/source/heater.cpp
+++ b/source/heater.cpp
@@ -13,13 +13,14 @@ Heater::Heater(tinyxml2::XMLElement * heating_node)
 
   //Set heating parameters
   tinyxml2::XMLElement * events = get_element(heating_node,"events");
+  minimum_duration = LARGEST_DOUBLE;
   for(tinyxml2::XMLElement *child = events->FirstChildElement();child != NULL;child=child->NextSiblingElement())
   {
     time_start_rise.push_back(std::stod(child->Attribute("rise_start")));
     time_end_rise.push_back(std::stod(child->Attribute("rise_end")));
     time_start_decay.push_back(std::stod(child->Attribute("decay_start")));
     time_end_decay.push_back(std::stod(child->Attribute("decay_end")));
-    magnitude.push_back(std::stod(child->Attribute("magnitude")));
+    minimum_duration = std::fmin(time_end_decay.back() - time_start_rise.back(),minimum_duration);    magnitude.push_back(std::stod(child->Attribute("magnitude")));
   }
   num_events = magnitude.size();
 

--- a/source/heater.h
+++ b/source/heater.h
@@ -8,6 +8,7 @@ Class definition for the heating object
 
 #include "helper.h"
 #include "../rsp_toolkit/source/xmlreader.h"
+#include "../rsp_toolkit/source/constants.h"
 
 // Heater object
 //
@@ -45,6 +46,9 @@ public:
 
   /* Partition of energy between electrons and ions; 1 corresponds to pure electron heating and 0 pure ion heating. For a single-fluid treatment, use 0.5 */
   double partition;
+
+  /* Duration of the shortest heating event; used to determine limit on timestep */
+  double minimum_duration;
 
   // Default constructor
   // @heating_node XML node holding the heating information

--- a/source/helper.h
+++ b/source/helper.h
@@ -25,7 +25,9 @@ struct Parameters {
   /* Loop half length (in cm) */
   double loop_length;
   /* Truncation error tolerance for adaptive solver */
-  double rka_error;
+  double adaptive_solver_error;
+  /* Safety factor on allowed timestep for adaptive solver */
+  double adaptive_solver_safety;
   /* Heat flux saturation limit; 1/6 is a typical value */
   double saturation_limit;
   /* Nominal conductive c1 value; 6.0 is recommended*/

--- a/source/loop.cpp
+++ b/source/loop.cpp
@@ -28,7 +28,8 @@ Loop::Loop(char *ebtel_config, char *rad_config)
   parameters.total_time = std::stod(get_element_text(root,"total_time"));
   parameters.tau = std::stod(get_element_text(root,"tau"));
   parameters.loop_length = std::stod(get_element_text(root,"loop_length"));
-  parameters.rka_error = std::stod(get_element_text(root,"rka_error"));
+  parameters.adaptive_solver_error = std::stod(get_element_text(root,"adaptive_solver_error"));
+  parameters.adaptive_solver_safety = std::stod(get_element_text(root,"adaptive_solver_safety"));
   parameters.saturation_limit = std::stod(get_element_text(root,"saturation_limit"));
   parameters.c1_cond0 = std::stod(get_element_text(root,"c1_cond0"));
   parameters.c1_rad0 = std::stod(get_element_text(root,"c1_rad0"));
@@ -86,6 +87,11 @@ Loop::~Loop(void)
   doc.Clear();
   delete heater;
   delete radiation_model;
+}
+
+double Loop::GetMaxAllowedTimestep(void)
+{
+  return heater->minimum_duration*parameters.adaptive_solver_safety;
 }
 
 state_type Loop::GetState(void)

--- a/source/loop.h
+++ b/source/loop.h
@@ -110,6 +110,17 @@ public:
   //
   void SaveTerms(void);
 
+  // Return maximum allowed timestep
+  //
+  // Maximum timestep is set by the input safety factor
+  // as well as the duration of the longest heating event. This
+  // is to prevent the timestep from blowing up during periods in
+  // which the loop is at equilibrium.
+  //
+  // @return maximum event duration times safety factor
+  //
+  double GetMaxAllowedTimestep(void);
+
   // Return current state publicly
   //
   // @return vector holding the current state of the loop

--- a/source/loop.h
+++ b/source/loop.h
@@ -113,11 +113,11 @@ public:
   // Return maximum allowed timestep
   //
   // Maximum timestep is set by the input safety factor
-  // as well as the duration of the longest heating event. This
+  // as well as the duration of the shortest heating event. This
   // is to prevent the timestep from blowing up during periods in
   // which the loop is at equilibrium.
   //
-  // @return maximum event duration times safety factor
+  // @return minimum event duration times safety factor
   //
   double GetMaxAllowedTimestep(void);
 

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -29,7 +29,7 @@ def run_tests():
     ih = InputHandler(os.path.join(top_dir,'config/ebtel.example.cfg.xml'))
     base_dir = ih.lookup_vars()
     base_dir['calculate_dem'] = True
-    base_dir['rka_error'] = 1e-8
+    base_dir['adaptive_solver_error'] = 1e-8
     for opts in test_options:
         #configure opttions
         base_dir['heating']['events'] = opts[0]


### PR DESCRIPTION
When there are long periods between heating events, the loop settles into eqm and the timestep can become quite large. When a new heating event happens, the adaptive stepper skips too far into the event and can't recover.

This PR introduces a limit as a fraction of the shortest event duration. This fraction can be set in the config file as `adaptive_solver_safety`. 
