### PR TITLE
Refine timestep if NaNs encountered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ config/radiation.local.cfg.xml
 config/ebtel.local.cfg.xml
 #scons
 .sconsign.dblite
+#vscode editor config
+.vscode/*
 
 ##c++
 # Compiled Object files

--- a/config/ebtel.example.cfg.xml
+++ b/config/ebtel.example.cfg.xml
@@ -14,7 +14,7 @@
   <use_adaptive_solver>False</use_adaptive_solver>
   <output_filename>ebtel++_results_file.txt</output_filename>
   <adaptive_solver_error>1e-6</adaptive_solver_error>
-  <adaptive_solver_safety>1.0</adaptive_solver_safety>
+  <adaptive_solver_safety>0.5</adaptive_solver_safety>
   <c1_cond0>2.0</c1_cond0>
   <c1_rad0>0.6</c1_rad0>
   <helium_to_hydrogen_ratio>0.075</helium_to_hydrogen_ratio>

--- a/docs/ext/index.md
+++ b/docs/ext/index.md
@@ -41,12 +41,18 @@ Additionally, if you'd like to run the included tests and examples, you'll need 
 * [seaborn](https://stanford.edu/~mwaskom/software/seaborn/index.html)
 
 ## Installation
-To download the code from GitHub and build the executable,
+To download the code from GitHub and compile the code,
 ```Shell
 $ git clone --recursive https://github.com/rice-solar-physics/ebtelPlusPlus.git
 $ cd ebtelPlusPlus
 $ scons
 ```
+If the compile step fails because the compiler cannot find the appropriate headers and/or libraries using the default locations, you can use the `--includepath` and/or `--libpath` flags, respectively. For example, if you've installed the Boost headers and libraries in `/usr/local/include` and `/usr/local/lib`,
+```
+$ scons --includepath=/usr/local/include --libpath=/usr/local/lib
+```
+For more information about the available flags that can be passed to `scons`, you can run `scons -h`.
+
 This will create an executable `bin/ebtel++.run`. To see the available command line parameters,
 ```Shell
 $ bin/ebtel++.run --help
@@ -86,7 +92,7 @@ An ebtel++ run is configured by a single XML configuration file. The table below
 | `use_adaptive_solver` | bool | if True, use adaptive timestep; significantly smaller compute times. In both cases, a Runge-Kutta Cash-Karp integration method is used (see section 16.2 of [Press et al. (1992)][press_num_recipes])  |
 | `output_filename` | string | path to output file |
 | `adaptive_solver_error` | float | Allowed truncation error in adaptive timestep routine |
-| `adaptive_solver_safety` | float | Limit on the allowed maximum timestep in units of the shortest event duration; should always be between 0 and 1. Not important for single or closely-spaced events |
+| `adaptive_solver_safety` | float | Refinement factor, between 0 and 1, used if timestep becomes too large and solution contains NaNs. Especially important for short, infrequently heated loops. |
 | `c1_cond0` | float | Nominal value of c1 during the conduction phase; see Appendix A of [Barnes et al. (2016)][barnes_2016] |
 | `c1_rad0` | float | Nominal value of c1 during radiative phase; see Eq. 16 of [Cargill et al. (2012a)][cargill_2012a] |
 | `helium_to_hydrogen_ratio` | float | Ratio of helium to hydrogen abundance; used in correction to ion mass, ion equation of state |

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
 
   // Set up Runge-Kutta integrator
   typedef boost::numeric::odeint::runge_kutta_cash_karp54< state_type > stepper_type;
-  auto controlled_stepper = boost::numeric::odeint::make_controlled(loop->parameters.adaptive_solver_error, loop->parameters.adaptive_solver_error, stepper_type());
+  auto controlled_stepper = boost::numeric::odeint::make_controlled(1e3*loop->parameters.adaptive_solver_error, loop->parameters.adaptive_solver_error, stepper_type());
   // Integrate
   num_steps = 0;
   if(loop->parameters.use_adaptive_solver)
@@ -74,13 +74,13 @@ int main(int argc, char *argv[])
     while(t<loop->parameters.total_time)
     {
       int fail = 1;
-      while(fail)
+      while(fail>0)
       {
         fail = controlled_stepper.try_step(loop->CalculateDerivs,state,t,tau);
-        if(!fail)
+        /*if(!fail)
         {
           fail = obs->CheckNan(state,t,tau);
-        }
+        }*/
       }
       // Enforce thermal conduction timescale limit
       double tau_tc = 4e-10*state[2]*pow(loop->parameters.loop_length,2)*pow(std::fmax(state[3],state[4]),-2.5);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -73,10 +73,14 @@ int main(int argc, char *argv[])
     // Start integration loop
     while(t<loop->parameters.total_time)
     {
-      int success = 1;
-      while(success!=0)
+      int fail = 1;
+      while(fail)
       {
-        success = controlled_stepper.try_step(loop->CalculateDerivs,state,t,tau);
+        fail = controlled_stepper.try_step(loop->CalculateDerivs,state,t,tau);
+        if(!fail)
+        {
+          fail = obs->CheckNan(state,t,tau);
+        }
       }
       // Enforce thermal conduction timescale limit
       double tau_tc = 4e-10*state[2]*pow(loop->parameters.loop_length,2)*pow(std::fmax(state[3],state[4]),-2.5);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
 
   // Set up Runge-Kutta integrator
   typedef boost::numeric::odeint::runge_kutta_cash_karp54< state_type > stepper_type;
-  auto controlled_stepper = boost::numeric::odeint::make_controlled(1e3*loop->parameters.adaptive_solver_error, loop->parameters.adaptive_solver_error, stepper_type());
+  auto controlled_stepper = boost::numeric::odeint::make_controlled(loop->parameters.adaptive_solver_error, loop->parameters.adaptive_solver_error, stepper_type());
   // Integrate
   num_steps = 0;
   if(loop->parameters.use_adaptive_solver)
@@ -85,8 +85,7 @@ int main(int argc, char *argv[])
       // Enforce thermal conduction timescale limit
       double tau_tc = 4e-10*state[2]*pow(loop->parameters.loop_length,2)*pow(std::fmax(state[3],state[4]),-2.5);
       tau = std::fmin(tau,0.5*tau_tc);
-      // Enforce limit set by duration of heating events
-      //tau = std::fmin(tau,loop->GetMaxAllowedTimestep());
+      // Save the state
       obs->Observe(state,t);
       num_steps += 1;
     }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -70,23 +70,23 @@ int main(int argc, char *argv[])
     // Initialize time and timestep
     double tau = loop->parameters.tau;
     double t = loop->parameters.tau;
+    double old_tau,old_t;
     // Start integration loop
     while(t<loop->parameters.total_time)
     {
       int fail = 1;
       while(fail>0)
       {
+        old_tau = tau;
+        old_t = t;
         fail = controlled_stepper.try_step(loop->CalculateDerivs,state,t,tau);
-        /*if(!fail)
-        {
-          fail = obs->CheckNan(state,t,tau);
-        }*/
+        if(!fail) fail = obs->CheckNan(state,t,tau,old_t,old_tau);
       }
       // Enforce thermal conduction timescale limit
       double tau_tc = 4e-10*state[2]*pow(loop->parameters.loop_length,2)*pow(std::fmax(state[3],state[4]),-2.5);
       tau = std::fmin(tau,0.5*tau_tc);
       // Enforce limit set by duration of heating events
-      tau = std::fmin(tau,loop->GetMaxAllowedTimestep());
+      //tau = std::fmin(tau,loop->GetMaxAllowedTimestep());
       obs->Observe(state,t);
       num_steps += 1;
     }

--- a/source/observer.cpp
+++ b/source/observer.cpp
@@ -41,3 +41,19 @@ void Observer::Observe(const state_type &state, const double time)
   // Increment counter
   i++;
 }
+
+int Observer::CheckNan(state_type &state, double &time, double &tau)
+{
+  for(int i=0; i<state.size(); i++)
+  {
+    if(std::isnan(state[i]))
+    {
+      time -= tau;
+      tau /= 1.5;
+      state = loop->GetState();
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/source/observer.cpp
+++ b/source/observer.cpp
@@ -42,18 +42,21 @@ void Observer::Observe(const state_type &state, const double time)
   i++;
 }
 
-int Observer::CheckNan(state_type &state, double &time, double &tau)
+int Observer::CheckNan(state_type &state, double &time, double &tau, double old_time, double old_tau)
 {
-  for(int i=0; i<state.size(); i++)
+  // Check for NaNs in the state
+  for(int j=0; j<state.size(); j++)
   {
-    if(std::isnan(state[i]))
+    if(std::isnan(state[j]))
     {
-      time -= tau;
-      tau /= 1.5;
+      // Reset and fail if NaNs found
+      time = old_time;
+      tau = old_tau*loop->parameters.adaptive_solver_safety;
       state = loop->GetState();
       return 1;
     }
   }
 
+  // Pass otherwise
   return 0;
 }

--- a/source/observer.h
+++ b/source/observer.h
@@ -53,7 +53,7 @@ public:
   // @old_tau previous timestep
   //
   // Boost integrator does not check for NaNs so this is done manually. If a
-  // NaN is found anywhere in the state vector, the state and time is set 
+  // NaN is found anywhere in the state vector, the state and time are set 
   // back to the previous step and the timestep is reduced.
   int CheckNan(state_type &state, double &time, double &tau, double old_time, double old_tau);
 };

--- a/source/observer.h
+++ b/source/observer.h
@@ -44,6 +44,17 @@ public:
   // from <Loop> and <Dem> to save relevant results. 
   //
   static void Observe(const state_type &state, const double time);
+
+  // Check result for NaNs
+  // @state current state of the loop system
+  // @time current time 
+  // @tau current timestep
+  //
+  // Boost integrator does not check for NaNs so this is done manually. If a
+  // NaN is found anywhere in the state vector, the state and time is set 
+  // back to the previous step and the timestep is reduced. Ideally, this 
+  // would be implemented as a template passed to the integrator.
+  int CheckNan(state_type &state, double &time, double &tau);
 };
 // Pointer to the <Observer> class
 typedef Observer* OBSERVER;

--- a/source/observer.h
+++ b/source/observer.h
@@ -54,7 +54,7 @@ public:
   // NaN is found anywhere in the state vector, the state and time is set 
   // back to the previous step and the timestep is reduced. Ideally, this 
   // would be implemented as a template passed to the integrator.
-  int CheckNan(state_type &state, double &time, double &tau);
+  int CheckNan(state_type &state, double &time, double &tau, double old_time, double old_tau);
 };
 // Pointer to the <Observer> class
 typedef Observer* OBSERVER;

--- a/source/observer.h
+++ b/source/observer.h
@@ -49,11 +49,12 @@ public:
   // @state current state of the loop system
   // @time current time 
   // @tau current timestep
+  // @old_time previous time
+  // @old_tau previous timestep
   //
   // Boost integrator does not check for NaNs so this is done manually. If a
   // NaN is found anywhere in the state vector, the state and time is set 
-  // back to the previous step and the timestep is reduced. Ideally, this 
-  // would be implemented as a template passed to the integrator.
+  // back to the previous step and the timestep is reduced.
   int CheckNan(state_type &state, double &time, double &tau, double old_time, double old_tau);
 };
 // Pointer to the <Observer> class


### PR DESCRIPTION
In cases of very short loops that are heated infrequently, it is very easy to encounter NaNs unless the timestep is severely limited. Unfortunately, the Boost ODE integrator methods used here allow NaNs to pass as a success and do not refine on the timestep, causing the routine to silently fail.

This PR fixes this by checking for NaNs, taking a step back and reducing the timestep until NaNs are fixed.

Also some minor documentation fixes.