### PR TITLE
Avoid really small timesteps

### DIFF
--- a/docs/ext/index.md
+++ b/docs/ext/index.md
@@ -92,7 +92,7 @@ An ebtel++ run is configured by a single XML configuration file. The table below
 | `use_adaptive_solver` | bool | if True, use adaptive timestep; significantly smaller compute times. In both cases, a Runge-Kutta Cash-Karp integration method is used (see section 16.2 of [Press et al. (1992)][press_num_recipes])  |
 | `output_filename` | string | path to output file |
 | `adaptive_solver_error` | float | Allowed truncation error in adaptive timestep routine |
-| `adaptive_solver_safety` | float | Refinement factor, between 0 and 1, used if timestep becomes too large and solution contains NaNs. Especially important for short, infrequently heated loops. |
+| `adaptive_solver_safety` | float | Refinement factor, between 0 and 1, used if timestep becomes too large and solution contains NaNs. Especially important for short, infrequently heated loops. Also controls decreases in timestep due to thermal conduction timestep. Suggested value is 0.5 |
 | `c1_cond0` | float | Nominal value of c1 during the conduction phase; see Appendix A of [Barnes et al. (2016)][barnes_2016] |
 | `c1_rad0` | float | Nominal value of c1 during radiative phase; see Eq. 16 of [Cargill et al. (2012a)][cargill_2012a] |
 | `helium_to_hydrogen_ratio` | float | Ratio of helium to hydrogen abundance; used in correction to ion mass, ion equation of state |

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -95,7 +95,8 @@ int main(int argc, char *argv[])
       }
       // Enforce thermal conduction timescale limit
       double tau_tc = 4e-10*state[2]*pow(loop->parameters.loop_length,2)*pow(std::fmax(state[3],state[4]),-2.5);
-      tau = std::fmin(tau,0.5*tau_tc);
+      // Limit abrupt changes in the timestep with safety factor 
+      tau = std::fmax(std::fmin(tau,0.5*tau_tc),loop->parameters.adaptive_solver_safety*tau);
       // Save the state
       obs->Observe(state,t);
       num_steps += 1;


### PR DESCRIPTION
Let the safety factor limit how small timestep gets when obeying the thermal conduction timestep limit. This helps to avoid file sizes blowing up, especially in the case of ion heating where there are huge ion temperature gradients.