### PR TITLE
Add parameter to control maximum allowed timestep

### DIFF
--- a/config/ebtel.example.cfg.xml
+++ b/config/ebtel.example.cfg.xml
@@ -2,7 +2,7 @@
 <root>
   <total_time>5000.0</total_time>
   <tau>1.0</tau>
-  <tau_max>1e+4</tau_max>
+  <tau_max>1e+300</tau_max>
   <loop_length>40.0e+8</loop_length>
   <saturation_limit>1.0</saturation_limit>
   <force_single_fluid>False</force_single_fluid>

--- a/config/ebtel.example.cfg.xml
+++ b/config/ebtel.example.cfg.xml
@@ -2,6 +2,7 @@
 <root>
   <total_time>5000.0</total_time>
   <tau>1.0</tau>
+  <tau_max>1e+4</tau_max>
   <loop_length>40.0e+8</loop_length>
   <saturation_limit>1.0</saturation_limit>
   <force_single_fluid>False</force_single_fluid>

--- a/docs/ext/index.md
+++ b/docs/ext/index.md
@@ -80,6 +80,7 @@ An ebtel++ run is configured by a single XML configuration file. The table below
 |:---------:|:----:|:------------|
 | `total_time` | float | duration of the simulation (in s)|
 | `tau` | float | timestep (in s); if using adaptive solver, the initial timestep |
+| `tau_max` | float | maximum allowed timestep (in s) when using adaptive solver |
 | `loop_length` | float | Loop half-length (in cm) |
 | `saturation_limit` | float | Flux limiter, _f_ in section 2.1 of [Barnes et al. (2016)][barnes_2016] |
 | `force_single_fluid` | bool | if True, electron and ion populations forced into equilibrium |

--- a/source/helper.h
+++ b/source/helper.h
@@ -23,6 +23,8 @@ struct Parameters {
   double total_time;
   /* Timestep (in s); when using adaptive solver, the initial timestep*/
   double tau;
+  /* Maximum allowed timestep (in s) when using adaptive solver */
+  double tau_max;
   /* Loop half length (in cm) */
   double loop_length;
   /* Truncation error tolerance for adaptive solver */

--- a/source/loop.cpp
+++ b/source/loop.cpp
@@ -27,6 +27,7 @@ Loop::Loop(char *ebtel_config, char *rad_config)
   //Numeric parameters
   parameters.total_time = std::stod(get_element_text(root,"total_time"));
   parameters.tau = std::stod(get_element_text(root,"tau"));
+  parameters.tau_max = std::stod(get_element_text(root,"tau_max"));
   parameters.loop_length = std::stod(get_element_text(root,"loop_length"));
   parameters.adaptive_solver_error = std::stod(get_element_text(root,"adaptive_solver_error"));
   parameters.adaptive_solver_safety = std::stod(get_element_text(root,"adaptive_solver_safety"));

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -97,6 +97,8 @@ int main(int argc, char *argv[])
       double tau_tc = 4e-10*state[2]*pow(loop->parameters.loop_length,2)*pow(std::fmax(state[3],state[4]),-2.5);
       // Limit abrupt changes in the timestep with safety factor 
       tau = std::fmax(std::fmin(tau,0.5*tau_tc),loop->parameters.adaptive_solver_safety*tau);
+      // Control maximum timestep
+      tau = std::fmin(tau,loop->parameters.tau_max);
       // Save the state
       obs->Observe(state,t);
       num_steps += 1;


### PR DESCRIPTION
Add in a parameter that does not allow for a timestep above some allowed limit. E.g.,

```cpp
tau = std::fmax(tau,loop->parameters.tau_max);
```

This is really only needed for *very* long delays between pulses or if for some reason you don't want a timestep above some given limit.