### PR TITLE
Use C++14 to account for newer versions of Boost

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -18,7 +18,7 @@ AddOption('--linkflags', dest='linkflags', type='string', nargs=1, action='store
 
 
 subdirs = ['source']
-cxx_flags = ['-std=c++11',]
+cxx_flags = ['-std=c++14',]
 try:
     CXX = os.environ['CXX']
 except KeyError:


### PR DESCRIPTION
Fixes #89 