### PR TITLE
Catch NaNs in static solver

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -14,7 +14,6 @@ int main(int argc, char *argv[])
 {
   //Declarations
   int num_steps;
-  int fail = 1;
   state_type state;
   char config[256];
   LOOP loop;
@@ -75,6 +74,7 @@ int main(int argc, char *argv[])
     // Start integration loop
     while(t<loop->parameters.total_time)
     {
+      int fail = 1;
       int num_failures = 0;
       while(fail>0)
       {
@@ -106,8 +106,7 @@ int main(int argc, char *argv[])
   {
     // Constant timestep integration
     num_steps = boost::numeric::odeint::integrate_const( controlled_stepper, loop->CalculateDerivs, state, loop->parameters.tau, loop->parameters.total_time, loop->parameters.tau, obs->Observe);
-    fail = obs->CheckNan(state);
-    if(fail)
+    if(obs->CheckNan(state))
     {
         throw std::runtime_error("NaNs were detected in the output.  Check the input configuration.");
     }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -14,6 +14,7 @@ int main(int argc, char *argv[])
 {
   //Declarations
   int num_steps;
+  int fail = 1;
   state_type state;
   char config[256];
   LOOP loop;
@@ -74,7 +75,6 @@ int main(int argc, char *argv[])
     // Start integration loop
     while(t<loop->parameters.total_time)
     {
-      int fail = 1;
       int num_failures = 0;
       while(fail>0)
       {
@@ -106,6 +106,11 @@ int main(int argc, char *argv[])
   {
     // Constant timestep integration
     num_steps = boost::numeric::odeint::integrate_const( controlled_stepper, loop->CalculateDerivs, state, loop->parameters.tau, loop->parameters.total_time, loop->parameters.tau, obs->Observe);
+    fail = obs->CheckNan(state);
+    if(fail)
+    {
+        throw std::runtime_error("NaNs were detected in the output.  Check the input configuration.");
+    }
   }
 
   //Print results to file

--- a/source/observer.cpp
+++ b/source/observer.cpp
@@ -60,3 +60,18 @@ int Observer::CheckNan(state_type &state, double &time, double &tau, double old_
   // Pass otherwise
   return 0;
 }
+
+int Observer::CheckNan(state_type &state)
+{
+  // Check for NaNs in the state
+  for(int j=0; j<state.size(); j++)
+  {
+    if(std::isnan(state[j]))
+    {
+      return 1;
+    }
+  }
+
+  // Pass otherwise
+  return 0;
+}

--- a/source/observer.h
+++ b/source/observer.h
@@ -55,7 +55,10 @@ public:
   // Boost integrator does not check for NaNs so this is done manually. If a
   // NaN is found anywhere in the state vector, the state and time are set 
   // back to the previous step and the timestep is reduced.
+  // The overloaded function, for use with the static time step solver, only checks for NaNs
+  // and does not reset the state or time.  
   int CheckNan(state_type &state, double &time, double &tau, double old_time, double old_tau);
+  int CheckNan(state_type &state);
 };
 // Pointer to the <Observer> class
 typedef Observer* OBSERVER;

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -83,3 +83,13 @@ def test_insufficient_heating(base_config, value):
     config['heating']['background'] = value
     with pytest.raises(EbtelPlusPlusError):
         run_ebtelplusplus(config)
+
+def test_NaNs_in_static_solver(base_config):
+    config = base_config.copy()
+    config['use_adaptive_solver'] = False
+    config['heating']['events'] = [
+                {'event': {'rise_start': 0.0, 'rise_end': 100.0, 'decay_start': 100.0,
+                           'decay_end': 200.0, 'magnitude': -10.0}}
+            ]
+    with pytest.raises(EbtelPlusPlusError):
+        run_ebtelplusplus(config)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -84,19 +84,10 @@ def test_insufficient_heating(base_config, value):
     with pytest.raises(EbtelPlusPlusError):
         run_ebtelplusplus(config)
 
-def test_NaNs_in_static_solver(base_config):
+@pytest.mark.parametrize('use_adaptive_solver', [True, False])
+def test_NaNs_in_solver(base_config, use_adaptive_solver):
     config = base_config.copy()
-    config['use_adaptive_solver'] = False
-    config['heating']['events'] = [
-                {'event': {'rise_start': 0.0, 'rise_end': 100.0, 'decay_start': 100.0,
-                           'decay_end': 200.0, 'magnitude': -10.0}}
-            ]
-    with pytest.raises(EbtelPlusPlusError):
-        run_ebtelplusplus(config)
-        
-def test_NaNs_in_adaptive_solver(base_config):
-    config = base_config.copy()
-    config['use_adaptive_solver'] = True
+    config['use_adaptive_solver'] = use_adaptive_solver
     config['heating']['events'] = [
                 {'event': {'rise_start': 0.0, 'rise_end': 100.0, 'decay_start': 100.0,
                            'decay_end': 200.0, 'magnitude': -10.0}}

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -93,3 +93,14 @@ def test_NaNs_in_static_solver(base_config):
             ]
     with pytest.raises(EbtelPlusPlusError):
         run_ebtelplusplus(config)
+        
+def test_NaNs_in_adaptive_solver(base_config):
+    config = base_config.copy()
+    config['use_adaptive_solver'] = True
+    config['heating']['events'] = [
+                {'event': {'rise_start': 0.0, 'rise_end': 100.0, 'decay_start': 100.0,
+                           'decay_end': 200.0, 'magnitude': -10.0}}
+            ]
+    with pytest.raises(EbtelPlusPlusError):
+        run_ebtelplusplus(config)
+


### PR DESCRIPTION
Fixes #33 

I figured it would be easier to catch it after the solver runs, given the speed of the code.  I've overloaded `Observer::CheckNaN` to simply perform the check, without resetting the state and time.