### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ results = ebtelplusplus.run(2*u.h, 40*u.Mm, heating)
 
 ## Citation
 
-If you use `ebtelplusplus` in any published work, it is greatly appreciate if you follow the [citation instructions here](https://ebtelplusplus.readthedocs.org/latest/en/index.html#citation).
+If you use `ebtelplusplus` in any published work, it is greatly appreciate if you follow the [citation instructions here](https://ebtelplusplus.readthedocs.io/en/latest/index.html#citation).

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ results = ebtelplusplus.run(2*u.h, 40*u.Mm, heating)
 
 ## Citation
 
-If you use `ebtelplusplus` in any published work, it is greatly appreciate if you follow the [citation instructions here](https://ebtelplusplus.readthedocs.io/en/latest/index.html#citation).
+If you use `ebtelplusplus` in any published work, it is greatly appreciated if you follow the [citation instructions here](https://ebtelplusplus.readthedocs.io/en/latest/index.html#citation).


### PR DESCRIPTION
The citation instructions link at the bottom of the readme was 404ing.  

