### PR TITLE
Make the docs build actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           python-version: '3.12'
           libraries:
             apt:
+              - graphviz
               - libboost-all-dev
 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The easiest way to install `ebtelplusplus` is through `pip`,
 pip install ebtelplusplus
 ```
 
-If you would like to compile and build the package from source, see [the instructions here](https://ebtelplusplus.readthedocs.org/latest/en/development.html).
+If you would like to compile and build the package from source, see [the instructions here](https://ebtelplusplus.readthedocs.org/en/latest/development.html).
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ docs = [
   "sphinx-copybutton",
   "sphinx-gallery",
   "matplotlib",
+  # Need pkg_resources for sphinxcontrib-bibtex
+  # and this comes from setuptools
+  "setuptools",
 ]
 dev = ["ebtelplusplus[test,docs]"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands_pre =
 commands =
     pytest --pyargs ebtelplusplus --cov ebtelplusplus --cov-report xml:coverage.xml --cov-report term-missing {posargs}
 
-[testenv:build_docs]
+[testenv:build_docs{,-gallery}]
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
 extras = docs

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ set_env =
 
 # Run the tests in a temporary directory to make sure that we don't import
 # the package from the source tree
-change_dir = .tmp/{envname}
+changedir = .tmp/{envname}
 
 deps =
     oldestdeps: minimum_dependencies


### PR DESCRIPTION
Due to bug in the `tox.ini` file, the docs build wasn't actually being run on the CI.