### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,10 @@ jobs:
         CIBW_BEFORE_BUILD_WINDOWS: choco install -y boost-msvc-14.2
         MACOSX_DEPLOYMENT_TARGET: 10.15
       targets: |
-        - cp3{10,11,12}-macosx_arm64
-        - cp3{10,11,12}-macosx_x86_64
-        - cp3{10,11,12}-manylinux_aarch64
-        - cp3{10,11,12}-manylinux_x86_64
-        - cp3{10,11,12}-win_amd64
+        - cp3{11,12,13}-macosx_arm64
+        - cp3{11,12,13}-macosx_x86_64
+        - cp3{11,12,13}-manylinux_aarch64
+        - cp3{11,12,13}-manylinux_x86_64
+        - cp3{11,12,13}-win_amd64
     secrets:
       pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       toxdeps: tox-pypi-filter
       envs: |
-        - linux: py312
+        - linux: py313
           libraries:
             apt:
               - libboost-all-dev
@@ -35,11 +35,11 @@ jobs:
     with:
       toxdeps: tox-pypi-filter
       envs: |
-        - linux: py310
+        - linux: py311
           libraries:
             apt:
               - libboost-all-dev
-        - macos: py311
+        - macos: py312
           libraries:
             brew:
               - boost
@@ -66,7 +66,7 @@ jobs:
     with:
       toxdeps: tox-pypi-filter
       envs: |
-        - windows: py312
+        - windows: py313
           libraries:
             choco:
               - boost-msvc-14.2
@@ -80,7 +80,7 @@ jobs:
       toxdeps: tox-pypi-filter
       envs: |
         - linux: build_docs-gallery
-          python-version: '3.12'
+          python-version: '3.13'
           libraries:
             apt:
               - graphviz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ keywords = [
   "science",
 ]
 dynamic = ["version"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "astropy",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 min_version = 4.0
 envlist =
-    py{310,311,312}-test
-    py10-test-oldestdeps
+    py{311,312,313}-test
+    py11-test-oldestdeps
     build_docs{,-gallery}
 
 [testenv]


### PR DESCRIPTION
Fixes #121 

This PR is an attempt at building binaries for Python 3.13.

- [x] Bump minimum version to 3.11 in `pyproject.toml`
- [x] Bump minimum test version in CI to 3.11
- [x] Bump tox file to 3.11, 3.12, 3.13
- [x] Test on Windows
- ~~[ ] Fix docs build error~~