### PR TITLE
Fix bug related to total pressure result and IDL comparison tests

### DIFF
--- a/ebtelplusplus/high_level.py
+++ b/ebtelplusplus/high_level.py
@@ -182,6 +182,4 @@ class EbtelResult:
             _, unit = typing.get_args(type_hints[k])
             setattr(self, k, u.Quantity(v, unit))
         self.inputs = inputs
-
-    def __post_init__(self):
         self.total_pressure = self.electron_pressure + self.ion_pressure

--- a/ebtelplusplus/tests/helpers.py
+++ b/ebtelplusplus/tests/helpers.py
@@ -17,6 +17,7 @@ _UNITS_MAPPING = {
     'pressure': 'dyne cm-2',
     'electron_pressure': 'dyne cm-2',
     'ion_pressure': 'dyne cm-2',
+    'velocity': 'cm s-1',
 }
 
 

--- a/ebtelplusplus/tests/test_compare_idl.py
+++ b/ebtelplusplus/tests/test_compare_idl.py
@@ -98,5 +98,5 @@ def test_compare_idl_area_expansion(
     assert u.allclose(r_cpp.electron_temperature, r_idl['temperature'], rtol=RTOL)
     assert u.allclose(r_cpp.ion_temperature, r_idl['temperature'], rtol=RTOL)
     assert u.allclose(r_cpp.density, r_idl['density'], rtol=RTOL)
-    assert u.allclose(r_cpp.electrong_pressure+r_cpp.ion_pressure, r_idl['pressure'], rtol=RTOL)
+    assert u.allclose(r_cpp.total_pressure, r_idl['pressure'], rtol=RTOL)
     assert u.allclose(r_cpp.velocity, r_idl['velocity'], rtol=RTOL)

--- a/ebtelplusplus/tests/test_solver.py
+++ b/ebtelplusplus/tests/test_solver.py
@@ -71,6 +71,7 @@ def static_results(physics_model, static_solver, heating_model):
     ('density', 1e7),
     ('electron_pressure', 1e-4),
     ('ion_pressure', 1e-4),
+    ('total_pressure', 1e-4),
     ('velocity', 1e4),
 ])
 def test_quantities_equal_adaptive_static(adaptive_results, static_results, name, atol):


### PR DESCRIPTION
This fixes three separate bugs:

1. The `total_pressure` field in the `EbtelResult` object was not actually being initialized.
2. The velocity units in the IDL comparison were not being passed correctly so the tests were failing every time on an attribute error
3. "electron_pressure" was spelled wrong when comparing this quantity in the IDL comparison test.