### PR TITLE
Fix docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.doctest",
     "sphinx.ext.mathjax",
+    "sphinx_autodoc_typehints",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
     "sphinx_gallery.gen_gallery",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ docs = [
   "sphinx-copybutton",
   "sphinx-design",
   "sphinx-gallery",
+  "sphinx-autodoc-typehints",
   "sphinx>=7.0",
   "sphinxcontrib-bibtex",
 ]


### PR DESCRIPTION
Fix docs build that was failing on warning about references to unit annotations not being found.